### PR TITLE
Throw an error when required common_environment variable is not valid

### DIFF
--- a/src/gtm/index.js
+++ b/src/gtm/index.js
@@ -13,11 +13,14 @@ function setPagename(pn) {
 function generateCommonParams(data) {
     var mergedPagename = merge({}, pagename, data);
 
-    if (!mergedPagename || !mergedPagename.country || !mergedPagename.market || !mergedPagename.category || !mergedPagename.pageid) {
+    if (!mergedPagename || !mergedPagename.country || !mergedPagename.market || !mergedPagename.category || !mergedPagename.pageid || !mergedPagename.environment) {
+        if (mergedPagename.environment === "test" || mergedPagename.environment === "live") {
+            throw new Error('Invalid environment type, ' + JSON.stringify(mergedPagename))
+        }
         throw new Error('Incorrect pagename, ' + JSON.stringify(mergedPagename));
     }
 
-    var commonPageName = [mergedPagename.country, mergedPagename.market, mergedPagename.category, mergedPagename.group, mergedPagename.pageid]
+    var commonPageName = [mergedPagename.country, mergedPagename.market, mergedPagename.category, mergedPagename.group, mergedPagename.pageid, mergedPagename.environment]
         .filter(function(x) {
             return x;
         })
@@ -33,8 +36,8 @@ function generateCommonParams(data) {
         common_category: mergedPagename.category,
         common_pageid: mergedPagename.pageid,
         common_pageName: commonPageName,
+        common_environment: mergedPagename.environment,
 
-        common_environment: mergedPagename.environment || '',
         common_language: mergedPagename.language || '',
         common_group: mergedPagename.group || '',
         common_layer: mergedPagename.layer || '',

--- a/src/gtm/index.js
+++ b/src/gtm/index.js
@@ -14,13 +14,13 @@ function generateCommonParams(data) {
     var mergedPagename = merge({}, pagename, data);
 
     if (!mergedPagename || !mergedPagename.country || !mergedPagename.market || !mergedPagename.category || !mergedPagename.pageid || !mergedPagename.environment) {
-        if (mergedPagename.environment === "test" || mergedPagename.environment === "live") {
+        if (mergedPagename.environment !== "test" || mergedPagename.environment !== "live") {
             throw new Error('Invalid environment type, ' + JSON.stringify(mergedPagename))
         }
         throw new Error('Incorrect pagename, ' + JSON.stringify(mergedPagename));
     }
 
-    var commonPageName = [mergedPagename.country, mergedPagename.market, mergedPagename.category, mergedPagename.group, mergedPagename.pageid, mergedPagename.environment]
+    var commonPageName = [mergedPagename.country, mergedPagename.market, mergedPagename.category, mergedPagename.group, mergedPagename.pageid]
         .filter(function(x) {
             return x;
         })


### PR DESCRIPTION
Hi there,
This PR is intended to make sure required common_environment variable correctly set (this can be only either 'live' or 'test').
Documentation was updated recently.
https://confluence.scout24.com/display/Analytics/001+General+Tracking+specifications
 
Not sure if we want to throw an error specifically for this variable so please let me know if it is necessary or not. 
Thanks in advance for reviewing!

Aoi